### PR TITLE
Support more node versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "12"
   - "14"
+  - "16"
 
 sudo: false

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "clean": "shx rm -rf ./dist ./test/**/*.js ./**/*.tsbuildinfo"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=12.0.0",
     "npm": ">=6.14.0"
   }
 }


### PR DESCRIPTION
This requirement reduces the required node version from `>=14` to `>=12`.

Requiring node 14 is a bit excessive because node 12 is still supported and there's nothing in this project that requires node 14.

I've also added node 12 and 16 to the Travis build. The current supported node versions are 12, 14, and 16.