### PR TITLE
General cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+        node: [ 12, 14, 16 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: npm ci
+#      - name: Lint TypeScript
+#        run: npm run lint
+      - name: Run test cases
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - "12"
-  - "14"
-  - "16"
-
-sudo: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,9 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^12.12.6",
         "chai": "^4.3.4",
-        "link-self": "^0.2.0",
         "mocha": "^9.1.1",
         "shx": "^0.3.3",
-        "typescript": "^4.4.2"
+        "typescript": "4.5.0-beta"
       },
       "engines": {
         "node": ">=12.0.0",
@@ -679,18 +678,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/link-self": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/link-self/-/link-self-0.2.0.tgz",
-      "integrity": "sha512-DOYsHSAq8zVWgUew9ujtrgyQDgI5bJL5zZntlamrH6WclG8kFV+8UudNk8xK+tilQGSydH+VOKZaoKjFMSkZAw==",
-      "dev": true,
-      "bin": {
-        "link-self": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1086,9 +1073,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.5.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.0-beta.tgz",
+      "integrity": "sha512-7PvWhki2lwukaR9osVhFnNzxaE4LM+gC94dlwcvS+Tqz8+U65va7FbKo02bT+/MFlnMPM8bsPUXvHiMD/Mg3Jg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1793,12 +1780,6 @@
         "argparse": "^2.0.1"
       }
     },
-    "link-self": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/link-self/-/link-self-0.2.0.tgz",
-      "integrity": "sha512-DOYsHSAq8zVWgUew9ujtrgyQDgI5bJL5zZntlamrH6WclG8kFV+8UudNk8xK+tilQGSydH+VOKZaoKjFMSkZAw==",
-      "dev": true
-    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2070,9 +2051,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.5.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.0-beta.tgz",
+      "integrity": "sha512-7PvWhki2lwukaR9osVhFnNzxaE4LM+gC94dlwcvS+Tqz8+U65va7FbKo02bT+/MFlnMPM8bsPUXvHiMD/Mg3Jg==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -38,13 +38,11 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^12.12.6",
     "chai": "^4.3.4",
-    "link-self": "^0.2.0",
     "mocha": "^9.1.1",
     "shx": "^0.3.3",
-    "typescript": "^4.4.2"
+    "typescript": "4.5.0-beta"
   },
   "scripts": {
-    "prepare": "link-self",
     "build": "tsc -b src && shx cp ./package.cjs.json ./dist/cjs/package.json",
     "pretest": "npm run build",
     "test": "tsc -b test && mocha",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "declaration": false,
-    "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true,
+    "module": "Node12",
     "outDir": "",
     "types": ["node", "mocha", "chai"]
   },

--- a/test/unknown.spec.ts
+++ b/test/unknown.spec.ts
@@ -1,6 +1,5 @@
 import {hasProperty} from "unknown";
-import chai from "chai";
-const expect = chai.expect;
+import {expect} from "chai";
 
 type KnownObject = { known: "known" };
 


### PR DESCRIPTION
Updated to TypeScript 4.5 Beta to test out self-referencing packages.
Removed `link-self` dependency (not needed anymore with self-referencing imports)
Switched from Travis CI to GitHub Actions.