### PR TITLE
Generate separate type declarations for CommonJS.

### DIFF
--- a/src/tsconfig.cjs.json
+++ b/src/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../dist/cjs",
-    "declarationDir": "../dist",
+    "declarationDir": "../dist/cjs",
     "module": "CommonJS"
   }
 }


### PR DESCRIPTION
Although these are identical to the type declarations for ESM, it is necessary to generate separate type declarations for CommonJS for compatibility with TypeScript's Node16/NodeNext module resolution modes.

See https://github.com/microsoft/TypeScript/issues/56529

See https://arethetypeswrong.github.io/?p=unknown%400.2.5

See https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseESM.md

With this change, TypeScript will resolve the types as follows in Node16/NodeNext modes:

 * When importing using require (CommonJS), match `"exports": ".": "require": "./dist/cjs/unknown.js"`, and resolve types to the accompanying `"./dist/cjs/unknown.d.ts"`.
 * Otherwise, match `"exports": ".": "default": "./dist/unknown.js"`, and resolve types to the accompanying `"./dist/unknown.d.ts"`.

Note that it is not necessary to specify `"types"` in `"exports"` because TypeScript will follow the node module resolution algorithm to resolve the JavaScript file that would be imported, and then automatically discover type definitions adjacent to that JavaScript file.

The top-level `"types"` entry is probably not required for the same reason, but I have left it alone for now for the sake of making a minimal change to solve this problem.

Without this change, when importing `unknown` from a CommonJS project with Node16/NodeNext module resolution, TypeScript reports:

```text
index.ts:1:27 - error TS1479: The current file is a CommonJS module whose
imports will produce 'require' calls; however, the referenced file is an
ECMAScript module and cannot be imported with 'require'. Consider writing a
dynamic 'import("unknown")' call instead.
```